### PR TITLE
updating id flow for eval

### DIFF
--- a/src/refined/constants/resources_constants.py
+++ b/src/refined/constants/resources_constants.py
@@ -471,9 +471,4 @@ TRAINING_DATA_FILES = {
         "s3_key": s3_resource_prefix + "training_data/wikipedia_links_aligned_spans.json",
         "local_filename": "wikipedia_links_aligned_spans.json"
     },
-    "wikipedia_training_dataset_tiny": {
-        "s3_bucket": s3_resource_bucket,
-        "s3_key": s3_resource_prefix + "training_data/wikipedia_links_aligned_spans.json",
-        "local_filename": "wikipedia_links_aligned_spans_tiny.json"
-    }
 }

--- a/src/refined/data_types/modelling_types.py
+++ b/src/refined/data_types/modelling_types.py
@@ -38,7 +38,7 @@ class BatchElementTns(NamedTuple):
     token_acc_sum_values: Optional[Tensor] = None  # shape = (seq_len, )
     entity_mask_values: Optional[Tensor] = None  # shape = (ent_len, )
     class_target_values: Optional[Tensor] = None  # shape = (all_ent_len, max_num_classes_per_ent)
-    # 🔭🌕 Galileo logging
+    # 🔭🌕 Galileo
     entity_ids: Optional[Tensor] = None  # shape = (all_ent_len, )
     attention_mask_values: Tensor = None  # shape = (seq_len, )
     token_type_values: Tensor = None  # shape = (seq_len, )
@@ -67,7 +67,7 @@ class BatchedElementsTns(NamedTuple):
     token_acc_sum_values: Optional[Tensor] = None  # shape = (bs, seq_len)
     entity_mask_values: Optional[Tensor] = None  # shape = (bs, ent_len)
     class_target_values: Optional[Tensor] = None  # shape = (all_ent_len, max_num_classes_per_ent)
-    # 🔭🌕 Galileo logging
+    # 🔭🌕 Galileo
     entity_ids: Optional[Tensor] = None  # shape = (bs, all_ent_len)
     attention_mask_values: Tensor = None  # shape = (bs, seq_len)
     token_type_values: Tensor = None  # shape = (bs, seq_len)
@@ -128,12 +128,12 @@ class BatchElement:
     # spans used for entity typing and entity disambiguation (could be partial labels)
     spans: Optional[List[Span]]
 
-    # 🔭🌕 Galileo logging
-    # Unique id for each span
-    span_ids: Optional[List[int]]
-
     # text from original document (note: this is the full text of the document)
     text: str
+
+    # 🔭🌕 Galileo
+    # Unique id for each span
+    span_ids: Optional[List[int]] = None
 
     # spans used for training mention detection (should be complete labels)
     md_spans: Optional[List[Span]] = None

--- a/src/refined/inference/processor.py
+++ b/src/refined/inference/processor.py
@@ -185,15 +185,15 @@ class Refined(object):
         if apply_class_check:
             self.preprocessor.class_check_spans(all_spans)
 
-        # can add labels and other entity ids to spans here
-
         return all_spans
 
-
+    # 🔭🌕 Galileo
+    # Add span ids argument
     def process_text(
             self,
             text: str,
             spans: Optional[List[Span]] = None,
+            span_ids: Optional[List[int]] = None,
             ner_threshold: float = 0.5,
             prune_ner_types: bool = True,
             max_batch_size: int = 16,
@@ -218,7 +218,7 @@ class Refined(object):
         all_spans = []
         if spans is not None:
             doc = Doc.from_text_with_spans(
-                text, spans, self.preprocessor, backward_coref=self.backward_coref
+                text, spans, self.preprocessor, backward_coref=self.backward_coref, span_ids=span_ids
             )
         else:
             doc = Doc.from_text(
@@ -445,10 +445,10 @@ class Refined(object):
             # This messes up the future conversion of BatchElements to BatchedElements
             # because it removes padded "Empty" Candidate entities -> each span can have a different
             # number of candidate entities.
-            # span.candidate_entities = [
-            #     (qcode, round(conf, 4))
-            #     for qcode, conf in filter(lambda x: not x[0] == "Q0", span.candidate_entities)
-            # ]
+            span.candidate_entities = [
+                (qcode, round(conf, 4))
+                for qcode, conf in filter(lambda x: not x[0] == "Q0", span.candidate_entities)
+            ]
             span.description_scores = round_list(
                 description_scores[span_idx].tolist(), 4
             )  # matches candidate order

--- a/src/refined/model_components/entity_typing_layer.py
+++ b/src/refined/model_components/entity_typing_layer.py
@@ -17,6 +17,7 @@ class EntityTyping(nn.Module):
         preprocessor: Optional[PreprocessorInferenceOnly] = None
     ):
         super().__init__()
+        # 🔭🌕 Galileo
         self.preprocessor = preprocessor
         self.dropout = nn.Dropout(dropout)  # not needed
         self.linear = nn.Linear(encoder_hidden_size, num_classes)
@@ -55,10 +56,10 @@ class EntityTyping(nn.Module):
             loss = loss_function(logits, targets)
 
             # 🔭🌕 Galileo logging
-            if self.preprocessor:
+            # Only log if IDs are present
+            if entity_ids is not None:
                 task_mask = self.preprocessor.lookups.label_subset_arr
 
-                # I think we need to detatch here
                 task_specific_logits = logits.detach()[:, task_mask]  # Shape = [batch, task_mask_shape]
                 task_specific_targets = targets.detach()[:, task_mask]
                 # Get the spans that actually have labels!

--- a/src/refined/model_components/refined_model.py
+++ b/src/refined/model_components/refined_model.py
@@ -70,7 +70,7 @@ class RefinedModel(nn.Module):
         )
         self.mention_embedding_dropout = nn.Dropout(config.ner_layer_dropout)
 
-        # TODO CHECK
+        # 🔭🌕 Galileo
         self.entity_typing: nn.Module = EntityTyping(
             dropout=config.ner_layer_dropout,
             num_classes=self.num_classes,
@@ -301,8 +301,12 @@ class RefinedModel(nn.Module):
         class_targets = self._expand_class_targets(
             batch.class_target_values, index_tensor=batch.entity_index_mask_values # This is generally a mask of all 1s! So we just take all entity targets
         )
+        # 🔭🌕 Galileo
         # Combine batch and entity axes: (bs, num_ent) -> (bs*(num_ent_per_row))
-        entity_ids = batch.entity_ids[batch.entity_index_mask_values]
+        if batch.entity_ids is not None:
+            entity_ids = batch.entity_ids[batch.entity_index_mask_values]
+        else:
+            entity_ids = None
 
         mention_embeddings = self._get_mention_embeddings(
             sequence_output=contextualised_embeddings,

--- a/src/refined/training/fine_tune/fine_tune.py
+++ b/src/refined/training/fine_tune/fine_tune.py
@@ -146,8 +146,9 @@ def run_fine_tuning_loops(refined: Refined, fine_tuning_args: TrainingArgs, trai
             if (step + 1) % checkpoint_every_n_steps == 0:
                 best_f1 = run_checkpoint_eval_and_save(best_f1, evaluation_dataset_name_to_docs, fine_tuning_args,
                                                        refined, optimizer=optimizer, scaler=scaler,
-                                                       scheduler=scheduler)
+                                                       scheduler=scheduler, log_to_galileo=False)
 
+        # 🔭🌕 Log evaluation ED to Galileo
         best_f1 = run_checkpoint_eval_and_save(best_f1, evaluation_dataset_name_to_docs, fine_tuning_args,
                                                refined, optimizer=optimizer, scaler=scaler,
                                                scheduler=scheduler, log_to_galileo=True)
@@ -157,11 +158,11 @@ def run_checkpoint_eval_and_save(best_f1: float, evaluation_dataset_name_to_docs
                                  fine_tuning_args: TrainingArgs, refined: Refined, optimizer: AdamW,
                                  scaler: GradScaler, scheduler, log_to_galileo: bool = False):
     torch.cuda.empty_cache()
-    # 🔭🌕 Galileo logging
+    # 🔭🌕 Galileo
     if not log_to_galileo:
         dq.disable_galileo()
-
     dq.set_split("validation")
+
     evaluation_metrics = evaluate(refined=refined,
                                   evaluation_dataset_name_to_docs=evaluation_dataset_name_to_docs,
                                   el=fine_tuning_args.el,  # only evaluate EL when training EL
@@ -197,6 +198,7 @@ def run_checkpoint_eval_and_save(best_f1: float, evaluation_dataset_name_to_docs
         torch.save(scheduler.state_dict(), os.path.join(model_output_dir, "scheduler.pt"))
         torch.save(scaler.state_dict(), os.path.join(model_output_dir, "scaler.pt"))
 
+    # 🔭🌕 Galileo
     dq.enable_galileo()
     torch.cuda.empty_cache()
     return best_f1

--- a/src/refined/training/train/train.py
+++ b/src/refined/training/train/train.py
@@ -111,7 +111,6 @@ def main():
         random_mask=0.0,
         lower_case_prob=0.0,
         candidate_dropout=0.0,
-        sample_k_candidates=5,
         max_mentions=25,  # prevents memory issues
         add_main_entity=True  # add weak labels,!
     )

--- a/src/refined/training/train/training_args.py
+++ b/src/refined/training/train/training_args.py
@@ -19,7 +19,7 @@ class TrainingArgs:
     class_name: str = 'TrainingArgs'
     experiment_name: str = f'{int(time.time())}'
     device: str = 'cuda:0' if torch.cuda.is_available() else 'cpu'
-    el: bool = False  # end-to-end entity linking (MD + ED + ET) when True else
+    el: bool = True  # end-to-end entity linking (MD + ED + ET) when True else
     # it will train entity disambiguation (ED) and entity typing (ET)
     ed_dropout: float = 0.05
     et_dropout: float = 0.10

--- a/src/refined/utilities/galileo_helpers.py
+++ b/src/refined/utilities/galileo_helpers.py
@@ -9,6 +9,7 @@ from refined.utilities.preprocessing_utils import convert_doc_to_tensors
 import dataquality as dq
 
 
+# 🔭🌕 Galileo
 def get_span_context(
     text: str, span_start: int, span_len: int
 ) -> str:
@@ -44,16 +45,14 @@ def get_span_context(
     return span_text_with_context.strip()
 
 
+# 🔭🌕 Galileo
 def log_input_data_galileo(
     dataset: WikipediaDataset,
     preprocessor: PreprocessorInferenceOnly,
     split: str,
     max_batch_size: int
 ) -> None:
-    """Log entity span data with Galileo as MLTC data
-
-
-    """
+    """Log entity span data with Galileo as MLTC data"""
     lookups = preprocessor.lookups
     # Create map from idx --> entity type name. Used for logging readable labels
     # Shift every by one to allow for the dummy 0th class
@@ -71,7 +70,6 @@ def log_input_data_galileo(
     span_labels = []
     span_ids = []
     meta_data = {"doc_id": [], "is_md_span": []}
-    # Why convert to a list?
     for data in dataset:
         # Handle the Validation dataset case where we have must convert documents first
         # to a list of BatchedElementsTns
@@ -114,5 +112,6 @@ def log_input_data_galileo(
         texts=span_texts,
         task_labels=span_labels,
         ids=span_ids,
-        split=split
+        split=split,
+        meta=meta_data
     )

--- a/src/refined/utilities/preprocessing_utils.py
+++ b/src/refined/utilities/preprocessing_utils.py
@@ -163,8 +163,12 @@ def convert_batch_element_to_tensors(
         dtype=torch.long
     )
 
+    # 🔭🌕 Galileo
     # Extract the new entity ids
-    entity_ids = torch.from_numpy(np.array(batch_element.span_ids))
+    if batch_element.span_ids is None:
+        entity_ids = None
+    else:
+        entity_ids = torch.from_numpy(np.array(batch_element.span_ids))
 
     return BatchElementTns(
         token_id_values,
@@ -399,8 +403,12 @@ def collate_batch_elements_tns(
     )
     b_ner_labels.fill_(ner_pad_value)
 
+    # 🔭🌕 Galileo
     # Add batch span_ids tensor
-    b_entity_ids = torch.zeros((batch_size, b_num_ents), dtype=torch.long)
+    if batch_elements_tns[0].entity_ids is None:
+        b_entity_ids = None
+    else:
+        b_entity_ids = torch.zeros((batch_size, b_num_ents), dtype=torch.long)
 
     for item_idx, batch in enumerate(batch_elements_tns):
         token_ln = batch.token_id_values.size(0)
@@ -419,7 +427,8 @@ def collate_batch_elements_tns(
         b_candidate_class_values[item_idx, :num_ents] = batch.candidate_class_values
 
         # Add span id info
-        b_entity_ids[item_idx, :num_ents] = batch.entity_ids
+        if b_entity_ids is not None and batch.entity_ids is not None:
+            b_entity_ids[item_idx, :num_ents] = batch.entity_ids
 
         if b_class_target_values is not None and batch.class_target_values is not None:
             b_class_target_values[item_idx, :num_ents] = batch.class_target_values


### PR DESCRIPTION
Changed the span id creating to better support the evaluation flow. We now allow both `el` and `ed` to be run during eval, but enforce that we only log to Galileo during `ed` when ids exist.