### PR TITLE
MusixMatch Request + Unblocking

### DIFF
--- a/src/refined/model_components/entity_typing_layer.py
+++ b/src/refined/model_components/entity_typing_layer.py
@@ -74,6 +74,7 @@ class EntityTyping(nn.Module):
                         logits=task_specific_logits,
                         ids=entity_ids
                     )
+
             return loss, logits.sigmoid()
 
         return None, logits.sigmoid()

--- a/src/refined/training/train/train.py
+++ b/src/refined/training/train/train.py
@@ -98,7 +98,7 @@ def main():
 
     eval_dataset = WikipediaDataset(
         start=0,
-        end=10,  # first 100 docs are used for eval
+        end=50,  # first 100 docs are used for eval
         preprocessor=preprocessor,
         resource_manager=resource_manager,
         wikidata_mapper=wikidata_mapper,

--- a/src/refined/utilities/galileo_helpers.py
+++ b/src/refined/utilities/galileo_helpers.py
@@ -6,6 +6,7 @@ from refined.dataset_reading.entity_linking.wikipedia_dataset import WikipediaDa
 from refined.doc_preprocessing.preprocessor import PreprocessorInferenceOnly
 from refined.utilities.preprocessing_utils import convert_doc_to_tensors
 
+from tqdm import tqdm
 import dataquality as dq
 
 
@@ -50,7 +51,7 @@ def log_input_data_galileo(
     dataset: WikipediaDataset,
     preprocessor: PreprocessorInferenceOnly,
     split: str,
-    max_batch_size: int
+    max_batch_size: int,
 ) -> None:
     """Log entity span data with Galileo as MLTC data"""
     lookups = preprocessor.lookups
@@ -69,8 +70,8 @@ def log_input_data_galileo(
     spans = []
     span_labels = []
     span_ids = []
-    meta_data = {"doc_id": [], "is_md_span": []}
-    for data in dataset:
+    meta_data = {"doc_id": [], "is_md_span": [], "entity_id": [], "entity_title": []}
+    for data in tqdm(dataset):
         # Handle the Validation dataset case where we have must convert documents first
         # to a list of BatchedElementsTns
         batches: List[BatchedElementsTns] = []
@@ -106,7 +107,10 @@ def log_input_data_galileo(
 
                     meta_data['doc_id'].append(span.doc_id)
                     meta_data['is_md_span'].append(span.is_md_span)
+                    meta_data['entity_id'].append(span.gold_entity.wikidata_entity_id)
+                    meta_data['entity_title'].append(span.gold_entity.wikipedia_entity_title)
 
+    print (len(span_texts))
     # 🔭🌕 Galileo logging
     dq.log_data_samples(
         texts=span_texts,

--- a/src/refined/utilities/galileo_helpers.py
+++ b/src/refined/utilities/galileo_helpers.py
@@ -71,6 +71,10 @@ def log_input_data_galileo(
     span_labels = []
     span_ids = []
     meta_data = {"doc_id": [], "is_md_span": [], "entity_id": [], "entity_title": []}
+
+    # To ensure sequential reading of the full dataset, set num_workers to 1
+    num_workers = dataset.num_workers
+    dataset.num_workers = 1
     for data in tqdm(dataset):
         # Handle the Validation dataset case where we have must convert documents first
         # to a list of BatchedElementsTns
@@ -110,7 +114,8 @@ def log_input_data_galileo(
                     meta_data['entity_id'].append(span.gold_entity.wikidata_entity_id)
                     meta_data['entity_title'].append(span.gold_entity.wikipedia_entity_title)
 
-    print (len(span_texts))
+    # Reset num workers
+    dataset.num_workers = num_workers
     # 🔭🌕 Galileo logging
     dq.log_data_samples(
         texts=span_texts,


### PR DESCRIPTION
### Key Features Added
1. Update the id assignment logic.
  - Create the "document index" --> "starting id" mapping. This must be done when sequentially iterating over the complete dataset. Thankfully we can do this when logging data to Galileo
  - During training use the pre-computed span_id mapping. This prevents issues when working with `num_works > 1`, which was causing ids to be incorrectly re-created.
2. Add a progress bar for processing the initial Dataset.
3. Include `entity_id` and `entity_title` as meta data.

For (1) we make sure that `num_workers` is set to 1 so that we sequentially log all of the documents. 